### PR TITLE
Fix a few broken localization tags

### DIFF
--- a/Kerbal Space Program/GameData/StationScience/Parts/StnSciLab.cfg
+++ b/Kerbal Space Program/GameData/StationScience/Parts/StnSciLab.cfg
@@ -72,7 +72,7 @@ PART
     requiredSkills = ScienceSkill
     ConverterName = #autoLOC_scilab_converter
     StartActionName = #autoLOC_statsci_startResearch
-    StopActionName = autoLOC_statsci_stopResearch
+    StopActionName = #autoLOC_statsci_stopResearch
     AutoShutdown = false
     GeneratesHeat = false
     UseSpecialistBonus = false

--- a/SampleAnalyzer.cs
+++ b/SampleAnalyzer.cs
@@ -331,7 +331,7 @@ namespace StationScience
             ret += Localizer.Format("#autoLOC_StatSci_analyseImp" + Math.Round(txValue * 100));
             if (kuarqsRequired > 0)
             {
-                ret += "\n\n"+ Localizer.Format("autoLOC_StatSci_KuarkReq") + kuarqsRequired;
+                ret += "\n\n"+ Localizer.Format("#autoLOC_StatSci_KuarkReq") + kuarqsRequired;
                 double productionRequired = 0.01;
                 if (kuarqHalflife > 0)
                 {

--- a/StationScienceModule.cs
+++ b/StationScienceModule.cs
@@ -366,7 +366,7 @@ namespace StationScience
             string ret = base.GetInfo();
             if (requiredSkills != "" && requiredSkills != "NA")
             {
-                ret += Localizer.Format("autoLOC_StatSci_skillReq", requiredSkills);
+                ret += Localizer.Format("#autoLOC_StatSci_skillReq", requiredSkills);
             }
             return ret;
 #if false


### PR DESCRIPTION
Several localization tags were missing their leading '#' character, so the tag name would appear in-game instead of the localized string.

(Note that I've only changed the source code here — I didn't commit a recompiled DLL.  The `AssemblyInfo.cs` file is missing from the Git repository, and although I was able to copy one from another project to build myself a DLL for testing, I don't think it'd be appropriate to commit that file since its `AssemblyInfo` metadata may be incorrect.)