### PR TITLE
Localization-related fixes to cyclotron part description

### DIFF
--- a/Kerbal Space Program/GameData/StationScience/english.cfg
+++ b/Kerbal Space Program/GameData/StationScience/english.cfg
@@ -202,7 +202,7 @@ Localization
     #autoLOC_StatSci_EuReq = Eurekas required: <<1>>
     #autoLOC_StatSci_LabReq = \n<color=#DD8800>Requires a TH-NKR Research Lab</color>
     #autoLOC_StatSci_KuarkReq = Kuarqs required: <<1>>
-    #autoLOC_StatSci_KuarkHalf = Kuarq decay halflife: <<1>> seconds\n
+    #autoLOC_StatSci_KuarkHalf = Kuarq decay halflife: <<1>> seconds
     #autoLOC_StatSci_KuarkProd = Production required: <<1>> kuarq/s
     #autoLOC_StatSci_CycReqM = \n<color=#DD8800>Requires <<1>> D-ZZY Cyclotrons</color>
     #autoLOC_StatSci_CycReq = \n<color=#DD8800>Requires a D-ZZY Cyclotron</color>

--- a/SampleAnalyzer.cs
+++ b/SampleAnalyzer.cs
@@ -331,7 +331,7 @@ namespace StationScience
             ret += Localizer.Format("#autoLOC_StatSci_analyseImp", Math.Round(txValue * 100));
             if (kuarqsRequired > 0)
             {
-                ret += "\n\n"+ Localizer.Format("#autoLOC_StatSci_KuarkReq", kuarqsRequired);
+                ret += "\n"+ Localizer.Format("#autoLOC_StatSci_KuarkReq", kuarqsRequired);
                 double productionRequired = 0.01;
                 if (kuarqHalflife > 0)
                 {

--- a/SampleAnalyzer.cs
+++ b/SampleAnalyzer.cs
@@ -328,10 +328,10 @@ namespace StationScience
         {
             string ret = "";
             string reqCyclo = "";
-            ret += Localizer.Format("#autoLOC_StatSci_analyseImp" + Math.Round(txValue * 100));
+            ret += Localizer.Format("#autoLOC_StatSci_analyseImp", Math.Round(txValue * 100));
             if (kuarqsRequired > 0)
             {
-                ret += "\n\n"+ Localizer.Format("#autoLOC_StatSci_KuarkReq") + kuarqsRequired;
+                ret += "\n\n"+ Localizer.Format("#autoLOC_StatSci_KuarkReq", kuarqsRequired);
                 double productionRequired = 0.01;
                 if (kuarqHalflife > 0)
                 {

--- a/SampleAnalyzer.cs
+++ b/SampleAnalyzer.cs
@@ -335,9 +335,9 @@ namespace StationScience
                 double productionRequired = 0.01;
                 if (kuarqHalflife > 0)
                 {
-                    ret += Localizer.Format("#autoLOC_StatSci_KuarkHalf", kuarqHalflife);
+                    ret += "\n" + Localizer.Format("#autoLOC_StatSci_KuarkHalf", kuarqHalflife);
                     productionRequired = kuarqsRequired * (1 - Math.Pow(.5, 1.0 / kuarqHalflife));
-                    ret += Localizer.Format("#autoLOC_StatSci_KuarkProd", productionRequired);
+                    ret += "\n" + Localizer.Format("#autoLOC_StatSci_KuarkProd", productionRequired);
                 }
                 if (productionRequired > 1)
                     reqCyclo = Localizer.Format("#autoLOC_StatSci_CycReqM", (Math.Ceiling(productionRequired)));

--- a/StationExperiment.cs
+++ b/StationExperiment.cs
@@ -291,6 +291,7 @@ namespace StationScience
                     if (ret != "") ret += "\n";
                     ret += Localizer.Format("#autoLOC_StatSci_KuarkHalf", kuarqHalflife);
                     productionRequired = kuarqsRequired * (1 - Math.Pow(.5, 1.0 / kuarqHalflife));
+                    ret += "\n";
                     ret += Localizer.Format("#autoLOC_StatSci_KuarkProd", productionRequired);
                 }
                 if (productionRequired > 1)


### PR DESCRIPTION
This is a follow-up to #1 that fixes some remaining problems with the WT-SIT cyclotron's part description.  (As with #1, I've only committed the code changes, not a recompiled DLL.)